### PR TITLE
Convert es6 code to es5

### DIFF
--- a/priv/client.js
+++ b/priv/client.js
@@ -9,12 +9,15 @@ import ReactDOM from 'react-dom'
  * @param {Function} componentMapper - A function that takes in a name and returns the component
  */
 export function hydrateClient(componentMapper) {
-  const serverRenderedComponents = document.querySelectorAll('[data-rendered]')
+  var serverRenderedComponents = document.querySelectorAll('[data-rendered]')
+  var serverRenderedComponentsLength = serverRenderedComponents.length;
 
-  for (const serverRenderedComponent of serverRenderedComponents) {
-    const component = componentMapper(serverRenderedComponent.dataset.component)
-    const props = JSON.parse(serverRenderedComponent.dataset.props)
-    const element = React.createElement(component, props)
+  for (var i = 0; i < serverRenderedComponentsLength; i++) {
+    var serverRenderedComponent = serverRenderedComponents[i];
+
+    var component = componentMapper(serverRenderedComponent.dataset.component)
+    var props = JSON.parse(serverRenderedComponent.dataset.props)
+    var element = React.createElement(component, props)
 
     ReactDOM.hydrate(element, serverRenderedComponent)
   }


### PR DESCRIPTION
Hi there,

As we spoke, here is the PR to convert some ES6 code to ES5.
This prevents Webpack builds with uglify to fail when you import the function `hydrateClient`.

Luís.