### PR TITLE
Allow importing react and react-dom as global 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,15 @@
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react"
+  ],
+  "plugins": [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-json-strings",
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Renders React as HTML
 
-## Documentation
+# Documentation
 
 The docs can
 be found at [https://hexdocs.pm/react_render](https://hexdocs.pm/react_render).
@@ -17,7 +17,7 @@ be found at [https://hexdocs.pm/react_render](https://hexdocs.pm/react_render).
 ```elixir
 def deps do
   [
-    {:react_render, "~> 2.0.0"}
+    {:react_render, "~> 2.0.3"}
   ]
 end
 ```
@@ -48,53 +48,107 @@ ReactRender.startServer()
 
 ```elixir
   render_service_path = "#{File.cwd!}/assets/js/server.js"
-  pool_size = 4
 
   supervisor(ReactRender, [[render_service_path: render_service_path, pool_size: 4]])
 ```
 
-- Create a react component like:
+# Working with Webpack
+Since the new version of Phoenix uses Webpack as the asset builder, we're going to leverage webpack features for our components.
 
-```js
-import React, {Component, createElement} from 'react'
+You need to add `React` and `react-dom` packages as your dependencies and these packages should be global so your application can render the components server side.
 
-class HelloWorld extends Component {
+## Make sure React and React-DOM are installed
+
+```
+# using npm
+npm install react react-dom --save
+```
+
+```
+# using yarn
+yarn add react react-dom
+```
+
+## Create an entry point on your webpack config
+For you to leverage caching and `react` as a global package so you don't need to import on each component, we advise you to create a file like `vendor.js` where this file will only contain you common packages that you would use on every component.
+
+Could be `react`, `jquery`, etc.
+In this case, we only need `react` and `react-dom`.
+
+```javascript
+entry: {
+  'js/vendor': path.resolve(__dirname, './js/vendor')
+},
+```
+
+## Create a vendor file and import on your phoenix template
+```javascript
+// vendor.js
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const jQuery = (window.jQuery = window.$ = require('jquery'));
+
+global.React = React;
+global.ReactDOM = ReactDOM;
+```
+
+```elixir
+# index.html.eex
+<script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/vendor.js") %>"></script>
+```
+
+## Create a react component like:
+
+```javascript
+class HelloWorld extends React.Component {
   render() {
-    const {name} = this.props
+    const { name } = this.props;
 
     return <div>Hello {name}</div>
   }
 }
 
-export default HelloWorld
+export default HelloWorld;
 ```
 
-- Call `ReactRender.render/2` inside the action of your controller
+## Call `ReactRender.render/2` inside your template where you want to add your react component
 
 ```elixir
-def index(conn, _params) do
-  component_path = "#{File.cwd!}/assets/js/HelloWorld.js"
-  props = %{name: "Revelry"}
-
-  { :safe, helloWorld } = ReactRender.render(component_path, props)
-
-  render(conn, "index.html", helloWorldComponent: helloWorld)
-end
+<div>
+  <%= ReactRender.render("#{File.cwd!}/assets/js/components/Home/index.jsx") %>
+</div>
 ```
 
 `component_path` can either be an absolute path or one relative to the render service. The stipulation is that components must be in the same path or a sub directory of the render service. This is so that the babel compiler will be able to compile it. The service will make sure that any changes you make are picked up. It does this by removing the component_path from node's `require` cache. If do not want this to happen, make sure to add `NODE_ENV` to your environment variables with the value `production`.
 
-- Render the component in the template
-
-```elixir
-<%= raw @helloWorldComponent %>
-```
-
 - To hydrate server-created components in the client, add the following to your `app.js`
 
-```js
-import {hydrateClient} from 'react_render/priv/client'
-import HelloWorld from './HelloWorld.js'
+## Hydrate your server-created components in the client
+We advise you to create a javascript file for each template where you will render server side react components and add as a webpack entry because this will be the file where you will import all of your components for that specific view.
+
+With this strategy, you only import and send to the client code that you will use.
+
+The folder structure for javascript files would be like:
+```
+assets
+  js
+    components
+      HelloWorld
+        index.jsx
+    views
+      Home
+        index.js
+    app.js (if you need)
+    vendor.js
+    server.js
+```
+
+```javascript
+// views/Home/index.js
+
+import { hydrateClient } from 'react_render/priv/client';
+import HelloWorld from './components/HelloWorld/index.js';
 
 function getComponentFromStringName(stringName) {
   // Map string component names to your react components here
@@ -106,4 +160,19 @@ function getComponentFromStringName(stringName) {
 }
 
 hydrateClient(getComponentFromStringName)
+```
+
+### Add as a webpack entry
+```javascript
+entry: {
+  'js/vendor': path.resolve(__dirname, './js/vendor'),
+  'js/home': path.resolve(__dirname, './js/views/Home'),
+},
+```
+
+### Import in the view that will render SS react components
+```elixir
+# index.html.eex
+<script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/vendor.js") %>"></script>
+<script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/home.js") %>"></script>
 ```

--- a/package.json
+++ b/package.json
@@ -12,11 +12,20 @@
     ".babelrc"
   ],
   "dependencies": {
-    "@babel/core": "^7.3.3",
+    "@babel/core": "^7.3.4",
     "@babel/polyfill": "^7.2.5",
-    "@babel/preset-env": "^7.3.1",
+    "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.3.4",
+    "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
+    "@babel/plugin-proposal-function-sent": "^7.2.0",
+    "@babel/plugin-proposal-json-strings": "^7.2.0",
+    "@babel/plugin-proposal-numeric-separator": "^7.2.0",
+    "@babel/plugin-proposal-throw-expressions": "^7.2.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+    "@babel/plugin-syntax-import-meta": "^7.2.0",
+    "@babel/runtime": "^7.3.4",
     "react": ">= 16.3 < 17",
     "react-dom": ">= 16.3 < 17"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react_render",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Bryan Joseph <bryan@revelry.co> (https://revelry.co)",
   "license": "MIT",
   "files": [

--- a/priv/client.js
+++ b/priv/client.js
@@ -1,6 +1,3 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-
 /**
  * Hydrates react components that had HTML created from server.
  * Looks for divs with 'data-rendered' attributes. Gets component

--- a/priv/nodejs/server.js
+++ b/priv/nodejs/server.js
@@ -7,7 +7,17 @@ require('@babel/register')({
   presets: [
     [require.resolve('@babel/preset-env')],
     [require.resolve('@babel/preset-react')]
-  ]
+  ],
+  plugins: [
+    require.resolve('@babel/plugin-syntax-dynamic-import'),
+    require.resolve('@babel/plugin-syntax-import-meta'),
+    require.resolve('@babel/plugin-proposal-class-properties'),
+    require.resolve('@babel/plugin-proposal-json-strings'),
+    require.resolve('@babel/plugin-proposal-function-sent'),
+    require.resolve('@babel/plugin-proposal-export-namespace-from'),
+    require.resolve('@babel/plugin-proposal-numeric-separator'),
+    require.resolve('@babel/plugin-proposal-throw-expressions'),
+  ],
 })
 
 function deleteCache(componentPath) {

--- a/priv/nodejs/server.js
+++ b/priv/nodejs/server.js
@@ -1,5 +1,5 @@
 const ReactServer = require('react-dom/server')
-const React = require('react')
+const React = global.React = require('react')
 const readline = require('readline')
 
 require('@babel/polyfill')


### PR DESCRIPTION
Hi,

This PR will help us to not need to import `react` on each component that we need to render server side. I've changed the `README` with instructions so everyone can leverage this strategy.

Luís Serrano.